### PR TITLE
Fix propTypes warning: 'oneOf' is for enums, 'oneOfType' is for types

### DIFF
--- a/SmartScrollView.js
+++ b/SmartScrollView.js
@@ -255,7 +255,7 @@ const styles = StyleSheet.create({
 });
 
 SmartScrollView.propTypes = {
-  forceFocusField:              PropTypes.oneOf(PropTypes.number, PropTypes.string),
+  forceFocusField:              PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   scrollContainerStyle:         View.propTypes.style,
   contentContainerStyle:        View.propTypes.style,
   zoomScale:                    PropTypes.number,


### PR DESCRIPTION
After adding this package as a dependency, when running our tests we were getting this:

>    console.error node_modules/react-native/Libraries/JavaScriptAppEngine/Initialization/ExceptionsManager.js:78
>      Warning: Invalid argument supplied to oneOf, expected an instance of array.

It was due to `PropTypes.oneOf(PropTypes.number, PropTypes.string)` which has some problems because `oneOf` takes an array, and `oneOf` is just for enums anyway, `oneOfType` is for types.

No big deal.  Anyway, here's the fix.

Thanks for making ReactNativeSmartScrollView!
